### PR TITLE
Changed Mailing implementation to use header multimap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.galan</groupId>
@@ -53,7 +54,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.8.6</version>
 		</dependency>
-		
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-guava</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 
 		<!-- logging bindings:slf4j -->
 		<dependency>
@@ -72,13 +77,13 @@
 			<artifactId>log4j-jul</artifactId>
 			<optional>true</optional>
 		</dependency>
-			<!-- logging bindings:jcl -->
+		<!-- logging bindings:jcl -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-jcl</artifactId>
 			<optional>true</optional>
 		</dependency>
-			<!-- logging bindings:log4j-1.x -->
+		<!-- logging bindings:log4j-1.x -->
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-1.2-api</artifactId>
@@ -159,8 +164,6 @@
 			<version>1.12.0</version>
 			<scope>test</scope>
 		</dependency>
-
-
 
 	</dependencies>
 

--- a/src/main/java/de/galan/commons/net/mail/Mail.java
+++ b/src/main/java/de/galan/commons/net/mail/Mail.java
@@ -1,15 +1,15 @@
 package de.galan.commons.net.mail;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.validation.Valid;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 
 
 /**
@@ -39,7 +39,7 @@ public class Mail {
 
 	private MailPriority priority = MailPriority.NORMAL;
 
-	private Map<String, String> header = new HashMap<String, String>();
+	private Multimap<String, String> header = HashMultimap.create();
 
 
 	public Mail() {
@@ -259,7 +259,7 @@ public class Mail {
 	}
 
 
-	public Map<String, String> getHeader() {
+	public Multimap<String, String> getHeader() {
 		return header;
 	}
 

--- a/src/main/java/de/galan/commons/net/mail/MailMessenger.java
+++ b/src/main/java/de/galan/commons/net/mail/MailMessenger.java
@@ -4,6 +4,7 @@ import static de.galan.commons.time.Instants.*;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
@@ -226,15 +227,18 @@ public class MailMessenger {
 		if (mail.hasHeaders()) {
 			for (String key: mail.getHeader().keySet()) {
 				String name = key;
-				String value = mail.getHeader().get(name);
-				try {
-					// Ensure only 7-Bit values
-					name = MimeUtility.encodeText(name, "US-ASCII", "Q");
-					value = MimeUtility.encodeText(value, "US-ASCII", "Q");
-					mimeMessage.addHeader(name, value);
-				}
-				catch (UnsupportedEncodingException e) {
-					Say.error("Could not add header, name: {name}, value: {value}", name, value);
+				Collection<String> values = mail.getHeader().get(name);
+
+				for (String value: values) {
+					try {
+						// Ensure only 7-Bit values
+						name = MimeUtility.encodeText(name, "US-ASCII", "Q");
+						value = MimeUtility.encodeText(value, "US-ASCII", "Q");
+						mimeMessage.addHeader(name, value);
+					}
+					catch (UnsupportedEncodingException e) {
+						Say.error("Could not add header, name: {name}, value: {value}", name, value);
+					}
 				}
 			}
 		}

--- a/src/test/java/de/galan/commons/net/mail/MailTest.java
+++ b/src/test/java/de/galan/commons/net/mail/MailTest.java
@@ -2,9 +2,15 @@ package de.galan.commons.net.mail;
 
 import javax.validation.ConstraintViolationException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.junit.Test;
 
 import de.galan.commons.util.Validations;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -91,4 +97,21 @@ public class MailTest {
 		Validations.validate(mail);
 	}
 
+
+	@Test
+	public void deserializeWithHeaders() throws Exception {
+		Mail mail = new Mail();
+		mail.addHeader("foo", "bar");
+		mail.addHeader("foo", "baz");
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new GuavaModule());
+
+		String json = mapper.writeValueAsString(mail);
+
+		Mail actual = mapper.readValue(json, Mail.class);
+
+		assertThat(actual.hasHeaders()).isTrue();
+		assertThat(actual.getHeader().get("foo")).contains("bar", "baz");
+	}
 }


### PR DESCRIPTION
It's possible for emails to have multiple headers with the same key. Therefore I've changed the implementation to use Multimap which unfortunately also necessitates the use of an additional plugin, the jackson-datatype-guava plugin.